### PR TITLE
Empty line before @media in block required

### DIFF
--- a/packages/style/index.js
+++ b/packages/style/index.js
@@ -119,7 +119,7 @@ module.exports = {
       "always",
       {
         "except": [
-          "inside-block"
+          "first-nested"
         ],
         "ignore": [
           "after-comment"


### PR DESCRIPTION
Empty line before @directive in block required, no empty line before first directive in a block.