### PR TITLE
feat(stylelint): Updated rules to ignore at content

### DIFF
--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -27,11 +27,10 @@ module.exports = {
           "/content/",
           "/each/",
           "/else/",
-          "/extend/",
           "/if/",
           "/include/",
-          "/mixin/",
-          "/media/"
+          "/media/",
+          "/mixin/"
         ]
       }
     ],

--- a/packages/stylelint-config/index.js
+++ b/packages/stylelint-config/index.js
@@ -24,8 +24,10 @@ module.exports = {
       true,
       {
         "ignoreAtRules": [
+          "/content/",
           "/each/",
           "/else/",
+          "/extend/",
           "/if/",
           "/include/",
           "/mixin/",


### PR DESCRIPTION
In order to have chatbot passing the linter tests, the @ rules @extend and @content must be ignored.