### PR TITLE
Update index.js

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -22,7 +22,6 @@ module.exports = {
     "new-cap": "off",
     "import/no-extraneous-dependencies": "off",
     "no-mixed-operators": "warn",
-    "no-underscore-dangle": ["error", { allow: ["__", "_satellite"] }],
     "@angular-eslint/component-class-suffix": "error",
     "@angular-eslint/directive-class-suffix": "error",
     "@angular-eslint/no-forward-ref": "error",


### PR DESCRIPTION
Seems those rules are the same
Line 25:  "no-underscore-dangle": ["error", { allow: ["__", "_satellite"] }],
Line 213: "no-underscore-dangle": [
      "error",
      {
        allow: ["_val", "__", "_satellite"],
        allowAfterThis: true,
        allowAfterSuper: true,
        enforceInMethodNames: false,
      },
    ],